### PR TITLE
Fails to compile on linux

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react"
-import "./app.css"
+import "./App.css"
 import Question from "./components/Question"
 import Sidebar from "./components/Sidebar"
 import QUESTION_LIST from "./questions/Clement"


### PR DESCRIPTION
Changed import from app.css to App.css, because it fails to compile on Linux due to case-sensitive filesystem.